### PR TITLE
Fix: correct undefined variable 'state' to 'input' in PydanticTransducerVLLM.execute() and dependencies imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,7 @@ dependencies = [
     "numerize>=0.12",
     "hnswlib>=0.8.0",
     "jsonfinder",
-    "crewai[google-genai]",
     "litellm",
-    "jsonfinder",
     "mellea",
     "plotly>=6.5.0",
 ]

--- a/src/agentics/core/async_executor.py
+++ b/src/agentics/core/async_executor.py
@@ -108,15 +108,6 @@ class PydanticTransducer(AsyncExecutor):
         pass
 
 
-from typing import Optional
-
-import mellea
-from langchain_core.output_parsers import PydanticOutputParser
-from langchain_core.prompts import PromptTemplate
-from pydantic import BaseModel, Field
-
-from agentics.core.utils import extract_json_objects
-
 # class PydanticTransducerMellea(PydanticTransducer):
 #     llm: AsyncOpenAI
 #     intentional_definiton: str
@@ -254,7 +245,7 @@ class PydanticTransducerVLLM(PydanticTransducer):
             result = await openai_response(
                 model=os.getenv("VLLM_MODEL_ID"),
                 base_url=os.getenv("VLLM_URL"),
-                user_prompt=default_user_prompt + str(state),
+                user_prompt=default_user_prompt + str(input),
                 **self.llm_params,
             )
             decoded_result = self.atype.model_validate_json(result)
@@ -285,9 +276,6 @@ class PydanticTransducerVLLM(PydanticTransducer):
             return decoded_results
         else:
             return NotImplemented
-
-
-from agentics.core.utils import llm_friendly_json
 
 
 class PydanticTransducerCrewAI(PydanticTransducer):


### PR DESCRIPTION
## Problem

- The `execute()` method in `PydanticTransducerVLLM` class was referencing an undefined variable `state` instead of the parameter `input` when handling single string inputs.
- Packages Imports were not defined at the beginning of the file. There were some duplicate imports in both `async_executor.py` and `pyproject.toml`