### PR TITLE
Relax pandas version constraint to >=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "plotly>=6.5.0",
     "rich>=13.0.0,<14.0.0",
     "duckdb>=1.4.3",
-    "pandas>=2.3.3",
+    "pandas>=2",
     "async-lru>=2.0.5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,7 @@ requires-dist = [
     { name = "numerize", specifier = ">=0.12" },
     { name = "openai", specifier = ">=1.88.0,<2.0.0" },
     { name = "openapi-python-client", specifier = ">=0.24.3,<0.25.0" },
-    { name = "pandas", specifier = ">=2.3.3" },
+    { name = "pandas", specifier = ">=2" },
     { name = "plotly", specifier = ">=6.5.0" },
     { name = "pydantic" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },


### PR DESCRIPTION
## Summary

- Relax the pandas version constraint from `>=2.3.3` to `>=2` in both `pyproject.toml` and `uv.lock`

## Changes
- Updated pandas dependency to support a broader range of versions
- This allows for more flexibility in dependency resolution and compatibility with projects using earlier pandas 2.x versions